### PR TITLE
Change README to address contributing to site

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,72 +1,32 @@
-[![Build Status](https://travis-ci.org/cosden/usrseweb.svg?branch=gh-pages)](https://travis-ci.org/cosden/usrseweb)
+[![Build Status](https://travis-ci.org/USRSE/usrseweb.svg?branch=gh-pages)](https://travis-ci.org/USRSE/usrseweb)
+
+
 
 ## The United States (US) Research Software Engineer Community
 
-The increasing use of digital technologies across research communities has gone hand
-in hand with a strong growth and reliance on software written or customized to solve
-research problems. This in turn is driving dialog around opportunities to
+## us-rse.org Website Hosting
 
-  * improve the development of, and
-  * incentivize useful sharing, curation, and ongoing maintenance of
+This repository contains the files for the official US RSE website hosted at <https://www.us-rse.org>.
 
-research software artifacts and related knowledge.
+The site is made to be built with [Jekyll](https://jekyllrb.com/).
 
-Of course, research software does not develop, curate, or maintain itself. Accordingly,
-widespread research software growth has included emerging roles for people who
-create, maintain, and contribute to the research software ecosystem. These roles can
-bring value directly through enabling specific research projects. They
-also bring value indirectly, through helping ensure enduring impact of research
-software innovations and by facilitating adequate reproducibility standards in
-digital science.
+## Contributing Content
 
-Positions like data steward, information manager, research data
-officer, research software engineer, research supporter, cyberinfrastructure
-engineer, campus champion, research computing facilitator, bioinformatician and
-other titles are increasingly found as core roles in research teams.
+We encourage the community to contribute to the content of the website.  
 
-Initiatives in the [UK](http://rse.ac.uk/), [Germany](http://www.de-rse.org/en), the
-[Netherlands](http://nl-rse.org) and elsewhere are bringing
-together the community of people writing and contributing to research software at
-the national and international level. In the US this encompasses
-universities, laboratories, knowledge institutes, companies and other
-enterprises. This site is part of that effort.
+Fork the repository, make your proposed changes, test locally (see below) and then create a pull request against `gh-pages`.
 
-Joining the US-RSE Community is easy!
 
-We maintain both a mailing list for announcements and updates as well as a Slack
-channel for conversations.
+## Testing (Previewing) Locally
 
-* Signup to our mailing list to stay informed about any activities!
-* [Join our slack channel](https://docs.google.com/forms/d/e/1FAIpQLScBQ6AYpYYK2wL21egcaVvH0ZEvtShU-0s-XbqnY3okUsyIZw/viewform)
+In the top level directory of your forked repository run `jekyll serve` and browse to <http://localhost:4000>.
+If you are having trouble try `rm -rf _site`, followed by `bundle update`, then `bundle exec jekyll serve`.
+
+
+
+
 
 <!--- ## Join us! --->
 
 <a href="https://docs.google.com/forms/d/e/1FAIpQLScBQ6AYpYYK2wL21egcaVvH0ZEvtShU-0s-XbqnY3okUsyIZw/viewform">
 <img width="250px" alt="signup button" src="img/signup.png"></a>
-
-## What is a Research Software Engineer?
-
-Research Software Engineers (RSEs) are professional roles that closely collaborate
-with discipline researchers to understand questions they are studying, and then develop
-applications and software systems to help address those questions. Many RSEs
-started out as researchers who spent a lot of time developing software to do
-their own research. Others have started as software developers who have developed a
-strong affinity with the research process.
-
-While the RSEs are increasingly valuable to the research community, they
-lack a formal place in the professional academic system. This can create
-challenges around long-term software sustainability, curation, and continuity. This
-in turn potentially impacts reproducibility of digital insights and results,
-that is fundamental to credible research.
-
-The term Research Software Engineer was created as a way to
-catalyze more effective professionalization of these roles.
-The goal is to mutually benefit the integrity of the digital research
-processes, further increase impact of digital approaches, and to
-improve career trajectories of capable practitioners that underpin
-these activities. We are working, together with RSE associations in the
-[UK](http://rse.ac.uk/), [Germany](http://www.de-rse.org/en),
-the [Netherlands](http://nl-rse.org), and elsewhere
-to highlight the RSE role, and to connect the
-broad RSE community in the United States together.
-

--- a/README.md
+++ b/README.md
@@ -4,24 +4,23 @@
 
 ## The United States (US) Research Software Engineer Community
 
-## us-rse.org Website Hosting
+## Community Website 
 
-This repository contains the files for the official US RSE website hosted at <https://www.us-rse.org>.
+This repository contains the files for the official US RSE website hosted at http://www.us-rse.org.
 
-The site is made to be built with [Jekyll](https://jekyllrb.com/).
+The site is built with [Jekyll](https://jekyllrb.com/) and hosted on GitHub. 
 
 ## Contributing Content
 
 We encourage the community to contribute to the content of the website.  
 
-Fork the repository, make your proposed changes, test locally (see below) and then create a pull request against `gh-pages`.
+To do this: fork the repository, make your proposed changes, test locally (see below), and then create a pull request against `gh-pages`.
 
 
 ## Testing (Previewing) Locally
 
 In the top level directory of your forked repository run `jekyll serve` and browse to <http://localhost:4000>.
 If you are having trouble try `rm -rf _site`, followed by `bundle update`, then `bundle exec jekyll serve`.
-
 
 
 

--- a/_config.yml
+++ b/_config.yml
@@ -5,7 +5,7 @@
 
 # If you are building a simple GitHub user page (https://username.github.io) then use these settings:
 url: "http://us-rse.org"
-baseurl: "/"
+baseurl: 
 
 # If you are building a GitHub project page then use these settings:
 #url: "http://username.github.io/projectname"


### PR DESCRIPTION
Updated README from a summary of US RSE (content now prominently featured on the website) to instructions for how to:
1. Propose site changes (fork and pull request)
2. Preview the site locally using jekyll

Also removed base URL "/" (that prevented local building/previewing) and fixed typo in travis-ci badge.