### PR TITLE
update pearc19 event format

### DIFF
--- a/pages/events-training.md
+++ b/pages/events-training.md
@@ -6,9 +6,10 @@ permalink: /events-training/
 
 ## Upcoming Events
 
-- __PEARC19__: Join us at [PEARC19](https://www.pearc19.pearc.org/) for a Birds of a Feather (BOF) 
+### Jul 28 - Aug 1 2019: [PEARC19](https://www.pearc19.pearc.org/)  ###
+Join us at [PEARC19](https://www.pearc19.pearc.org/) for a Birds of a Feather (BOF) 
 session "Building a Community of Research Software Engineers."  Check back here or at 
-[PEARC19](https://www.pearc19.pearc.org/) for more details and scheduling information. 
+the [conference website](https://www.pearc19.pearc.org/) for more details and scheduling information. 
 
 <br> <br> <br> <br>
 


### PR DESCRIPTION
Minor change based on @cferenba suggestion in #27 discussion.  Now includes date/name of event as a heading.