### PR TITLE
Add twitter meta to header.html

### DIFF
--- a/_includes/header.html
+++ b/_includes/header.html
@@ -1,5 +1,10 @@
 <!-- TODO this file has become a mess, refactor it -->
 
+<!-- display logo when linked on Twitter -->
+<meta name="twitter:card" content="summary" />   <!-- or summary_large_image -->
+<meta name="twitter:image" content="{{ site.url }}/assets/img/logo.png" />
+
+
 {% if page.bigimg or page.title %}
 
 {% if page.bigimg %}


### PR DESCRIPTION
This change adds twitter meta data in order to display our fancy logo when a link is posted on Twitter.  I'm guessing that this is the best place to put it (header.html), but I could easily be wrong.

I don't know a good way to test this other than publishing my local fork and then using this https://cards-dev.twitter.com/validator. 

This is what it would look like now (before):
![image](https://user-images.githubusercontent.com/5824618/58373849-aec02180-7f02-11e9-8f31-55536f8c2b0b.png)

And with the change on my fork:
![image](https://user-images.githubusercontent.com/5824618/58373973-057a2b00-7f04-11e9-8a07-74f9e282a705.png)


