### PR TITLE
updating twitter metadata (that already is included)

### DIFF
--- a/_includes/head.html
+++ b/_includes/head.html
@@ -93,9 +93,11 @@
 
 
   <!-- Twitter summary cards -->
-  <meta name="twitter:card" content="summary" />
+  {% if site.author.twitter %}
   <meta name="twitter:site" content="@{{ site.author.twitter }}" />
   <meta name="twitter:creator" content="@{{ site.author.twitter }}" />
+  {% endif %} 
+  <meta name="twitter:card" content="summary" />
 
   {% if page.meta-title %}
   <meta name="twitter:title" content="{{ page.meta-title }}" />
@@ -115,8 +117,8 @@
 
   {% if page.share-img %}
   <meta name="twitter:image" content="{{ page.share-img }}" />
-  {% elsif site.avatar %}
-  <meta name="twitter:image" content="{{ site.url }}{{ site.avatar }}" />
+  {% elsif site.title-img %}
+  <meta name="twitter:image" content="{{ site.title-img }}" />
   {% endif %}
 
   {% if site.matomo %}


### PR DESCRIPTION
Hey @cosden! Apologies for missing this for your PR, but the site already is hooked up for Twitter image / cards, and what we just needed to do is ensure that the title-img (the logo) is used instead of a custom twitter avatar. Also, in the case that we get a handle for USRSE, filling in the field "author.twitter" in _config.yml will populate the rest.

I also added an if statement for the twitter handle, because as is (if you look at the source) it renders an empty @.

Signed-off-by: vsoch <vsochat@stanford.edu>