### PR TITLE
Change base url to us-rse.org

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -4,7 +4,7 @@
 # baseurl is the website's URL without the hostname
 # DO NOT CHANGE THE LINE NUMBERS HERE without changing .circleci/circle_urls.sh
 # If you are building a simple GitHub user page (https://username.github.io) then use these settings:
-url: "https://usrse.github.io"
+url: "https://us-rse.org"
 baseurl: ""
 title-img: /assets/img/logo.png
 


### PR DESCRIPTION
The logo at the top left points to https://urseweb.github.io (and gives a 404).  It looks like it's coming from site.baseurl.  I know this is the long term plan, but not until we rename the repo. 

So for now I've put it back to us-rse.org.  I don't think this will impact any other links, etc. 