### PR TITLE
updating twitter image to have full url

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -7,6 +7,7 @@
 url: "https://usrse.github.io"
 baseurl: ""
 title-img: /assets/img/logo.png
+twitter-img: https://us-rse.org/assets/img/logo.png
 
 # If you are building a GitHub project page then use these settings:
 #url: "http://username.github.io/projectname"

--- a/_includes/head.html
+++ b/_includes/head.html
@@ -117,8 +117,8 @@
 
   {% if page.share-img %}
   <meta name="twitter:image" content="{{ page.share-img }}" />
-  {% elsif site.title-img %}
-  <meta name="twitter:image" content="{{ site.title-img }}" />
+  {% elsif site.twitter-img %}
+  <meta name="twitter:image" content="{{ site.twitter-img }}" />
   {% endif %}
 
   {% if site.matomo %}


### PR DESCRIPTION
It was an oversight of me to not have a full url for the twitter image! However, we probably don't want to hard code the full url (the preview might break). So instead, it doesn't hurt to have a custom variable that is obviously for the twitter card.

Signed-off-by: Vanessa Sochat <vsochat@stanford.edu>